### PR TITLE
Bugfix of a bug that I introduced with my previous pull request.

### DIFF
--- a/cz
+++ b/cz
@@ -86,21 +86,23 @@ xkb_symbols "cz_programmer" {
     include "us"
     name[Group1]= "Czech programmer's";
 
-    key <AE02>{[         2,          at,     ecaron,     Ecaron ]};
-    key <AE03>{[         3,  numbersign,     scaron,     Scaron ]};
-    key <AE04>{[         4,      dollar,     ccaron,     Ccaron ]};
-    key <AE05>{[         5,     percent,     rcaron,     Rcaron ]};
-    key <AE06>{[         6, asciicircum,     zcaron,     Zcaron ]};
-    key <AE07>{[         7,   ampersand,     yacute,     Yacute ]};
-    key <AE08>{[         8,    asterisk,     aacute,     Aacute ]};
-    key <AE09>{[         9,   parenleft,     iacute,     Iacute ]};
-    key <AE10>{[         0,  parenright,     eacute,     Eacute ]};
-    key <AE12>{[     equal,        plus, dead_acute, dead_caron ]};
+    key <AE02>{[         2,          at,        ecaron,     Ecaron ]};
+    key <AE03>{[         3,  numbersign,        scaron,     Scaron ]};
+    key <AE04>{[         4,      dollar,        ccaron,     Ccaron ]};
+    key <AE05>{[         5,     percent,        rcaron,     Rcaron ]};
+    key <AE06>{[         6, asciicircum,        zcaron,     Zcaron ]};
+    key <AE07>{[         7,   ampersand,        yacute,     Yacute ]};
+    key <AE08>{[         8,    asterisk,        aacute,     Aacute ]};
+    key <AE09>{[         9,   parenleft,        iacute,     Iacute ]};
+    key <AE10>{[         0,  parenright,        eacute,     Eacute ]};
+    key <AE12>{[     equal,        plus,    dead_acute, dead_caron ]};
 
-    key <AD11>{[ bracketleft, braceleft,     uacute,     Uacute ]};
+    key <AD11>{[ bracketleft, braceleft,        uacute,     Uacute ]};
 
-    key <AC10>{[ semicolon,      colon,       uring,      Uring ]};
-    key <AC11>{[ apostrophe,  quotedbl,     section,   quotedbl ]};
+    key <AC10>{[ semicolon,      colon,          uring,      Uring ]};
+    key <AC11>{[ apostrophe,  quotedbl,        section,   quotedbl ]};
+
+    key <BKSL>{[ backslash,  brokenbar, dead_diaeresis, apostrophe ]};
 
     include "level3(ralt_switch)"
 };

--- a/cz
+++ b/cz
@@ -102,7 +102,7 @@ xkb_symbols "cz_programmer" {
     key <AC10>{[ semicolon,      colon,          uring,      Uring ]};
     key <AC11>{[ apostrophe,  quotedbl,        section,   quotedbl ]};
 
-    key <BKSL>{[ backslash,  brokenbar, dead_diaeresis, apostrophe ]};
+    key <BKSL>{[ backslash,        bar, dead_diaeresis, apostrophe ]};
 
     include "level3(ralt_switch)"
 };


### PR DESCRIPTION
The `BKSL` button pressed with shift would create a broken bar instead of the appropriate regular vertical bar. I only noticed this mistake of mine today. I apologize.